### PR TITLE
Hotfix/guardian 44, again: remove hidden zip artifacts

### DIFF
--- a/guardian-glacier-transfer
+++ b/guardian-glacier-transfer
@@ -389,10 +389,19 @@ TodoRunner.define do
     # TODO: Make sure data[:workspace] is deleted
     todo_data[:cleanup_directories].split('|').each do |dir|
       next unless File.exist?(dir)
+      LOGGER.debug("Processing for removal: #{dir}")
       (Dir.entries(dir) - %w(. ..)).each do |path|
-        git_annex_drop(path) if todo_data[:method] == 'gitannex' && File.extname(path) == '.git'
-        FileUtils.rm_rf(path, :secure => true)
+        LOGGER.debug("Removal entry is: #{path}")
+        if todo_data[:method] == 'gitannex' && File.extname(path) == '.git'
+          Dir.chdir(dir) do
+            git_annex_drop(path)
+          end
+        end
+        disk_file_path = File.join(dir, path)
+        LOGGER.debug("Removing: #{disk_file_path}")
+        FileUtils.rm_rf(disk_file_path, :secure => true)
       end
+      LOGGER.debug("Removing: #{dir}")
       FileUtils.rmdir(dir)
     end
   end

--- a/guardian-glacier-transfer
+++ b/guardian-glacier-transfer
@@ -390,16 +390,13 @@ TodoRunner.define do
     todo_data[:cleanup_directories].split('|').each do |dir|
       next unless File.exist?(dir)
       LOGGER.debug("Processing for removal: #{dir}")
-      (Dir.entries(dir) - %w(. ..)).each do |path|
-        LOGGER.debug("Removal entry is: #{path}")
-        if todo_data[:method] == 'gitannex' && File.extname(path) == '.git'
-          Dir.chdir(dir) do
-            git_annex_drop(path)
-          end
+      Dir.chdir(dir) do
+        (Dir.entries('.') - %w(. ..)).each do |path|
+          LOGGER.debug("Removal entry is: #{path}")
+          git_annex_drop(path) if todo_data[:method] == 'gitannex' && File.extname(path) == '.git'
+          LOGGER.debug("Removing: #{path}")
+          FileUtils.rm_rf(path, :secure => true)
         end
-        disk_file_path = File.join(dir, path)
-        LOGGER.debug("Removing: #{disk_file_path}")
-        FileUtils.rm_rf(disk_file_path, :secure => true)
       end
       LOGGER.debug("Removing: #{dir}")
       FileUtils.rmdir(dir)


### PR DESCRIPTION
Re-addresses issue #44 'Glacier transfer does not remove all zip artifacts in hidden directories'.

This change corrects a path error from the original hot fix. The pre-hot fix code had used `Dir.glob("#{path}/*")` to get removal paths, which gave absolute paths, but missed hidden files and directories. The first iteration of this hot fix used `Dir.entries(path)`, which returns *relative* paths; however, the method did not adjust the relative path in calls to `FileUtils.rm_rf`; thus, the method removed no files.

This fix changes the working directory to the path to delete, and then calls `Dir.entries('.')`. 